### PR TITLE
Bug fix missing order update 1 b

### DIFF
--- a/main/bots/SCALE_T/trading/constants.py
+++ b/main/bots/SCALE_T/trading/constants.py
@@ -4,3 +4,10 @@ from enum import Enum, auto
 class MessageType(Enum):
     PRICE_UPDATE = auto()
     ORDER_UPDATE = 'order_update'
+
+class OrderState(Enum):
+    NONE = auto()
+    BUYING = auto()
+    SELLING = auto()
+    CANCELLING = auto()
+    

--- a/main/bots/SCALE_T/trading/constants.py
+++ b/main/bots/SCALE_T/trading/constants.py
@@ -1,0 +1,6 @@
+from enum import Enum, auto
+
+
+class MessageType(Enum):
+    PRICE_UPDATE = auto()
+    ORDER_UPDATE = 'order_update'


### PR DESCRIPTION
Turns out the order update wasn't missing

It was just that the queue was too filled with so many prices that order update was far in the queue triggering repeated decision making. 

Instead of trying to make a decision, we now have order_state. If there is an order there already. There is only 2 possible decision paths. Cancel the order or leave the order alone. In our case. We skip the cancel if the new order_state is in CANCELLING. Preventing duplicate work and helping fly through the price updates. THis makes the 2 possible decision paths resolve to 1 in most cases :) 